### PR TITLE
Fix ESLint config for jest tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,15 @@ module.exports = [
   },
   js.configs.recommended,
   {
+    files: ['**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.es2020,
+      },
+    },
+  },
+  {
     files: ['**/*.ts'],
     ignores: ['node_modules/**'],
     languageOptions: {
@@ -30,6 +39,14 @@ module.exports = [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       'prettier/prettier': 'error',
+    },
+  },
+  {
+    files: ['**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
     },
   },
 ];

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -1,7 +1,10 @@
 import { Repository } from '../repository';
 
 describe('Repository', () => {
-  interface Item { id: number; value: string }
+  interface Item {
+    id: number;
+    value: string;
+  }
 
   it('adds and retrieves item by id', () => {
     const repo = new Repository<Item>();


### PR DESCRIPTION
## Summary
- add Node and Jest globals to ESLint config so test files lint cleanly
- format repository.test.ts interface using Prettier style

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68448b3ac918832296e42c5c6882a2e1